### PR TITLE
fix unWISE URL

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -74,7 +74,7 @@ NAVIGATION_LINKS = {
             ("decals", 'DECaLS'),
             ("http://www.darkenergysurvey.org", 'DES'),
 #            ("http://batc.bao.ac.cn/BASS", 'BASS'),
-            ("http:unwise.com", 'unWISE'),
+            ("http://unwise.me", 'unWISE'),
             ), 'Inputs'),
         ((
             ("http://astrometry.net", 'astrometry.net'),


### PR DESCRIPTION
Hi David,

I was looking around the website and noticed the unWISE link was broken. If you want me to be a more frequent/substantial contributor to the website, you might consider giving me write access to this repo as a "collaborator" (at the risk of me breaking things).

Also, another somewhat unrelated suggestion of mine would be to make a new DECaLS organization page at github.com/legacysurvey (currently available), and move this repo there under the name "website". I believe organization pages are free unless they contain private repos. @dstndstn might have an opinion about this idea. Thanks very much.

-Aaron